### PR TITLE
Update bugged version of @mswjs/interceptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vitest": "^2.1.2"
   },
   "dependencies": {
-    "@mswjs/interceptors": "^0.36.4",
+    "@mswjs/interceptors": "^0.37.3",
     "regexparam": "^3.0.0"
   }
 }


### PR DESCRIPTION
Version 0.36.4 of @mswjs/interceptors created a bug when using the option `onUnhandled` of `installInterceptor`.

Version 0.37.3 solves this issue.